### PR TITLE
feat: add support for raw content from providers

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -11,11 +11,11 @@ _Last updated: May 15, 2025_
   - [x] Update shutdown handler for stdio transport
   - [x] Add CLI argument parser to support transport options and API keys
 
-- [ ] Add support for returning raw content from providers when requested
+- [x] Add support for returning raw content from providers when requested
 
-  - [ ] Update SearchQuery model to add raw_content: bool parameter
-  - [ ] Modify provider implementations to include full content when raw_content=True
-  - [ ] Update result processing to handle raw content appropriately
+  - [x] Update SearchQuery model to add raw_content: bool parameter
+  - [x] Modify provider implementations to include full content when raw_content=True
+  - [x] Update result processing to handle raw content appropriately
 
 - [ ] Add health check and metrics endpoints
   - [ ] Implement health check route using @mcp.custom_route("/health")

--- a/mcp_search_hub/models/query.py
+++ b/mcp_search_hub/models/query.py
@@ -26,6 +26,9 @@ class SearchQuery(BaseModel):
     timeout_ms: int = Field(
         5000, description="Timeout in milliseconds", ge=1000, le=30000
     )
+    raw_content: bool = Field(
+        False, description="Whether to include raw content in search results"
+    )
 
 
 class QueryFeatures(BaseModel):

--- a/mcp_search_hub/models/results.py
+++ b/mcp_search_hub/models/results.py
@@ -12,6 +12,9 @@ class SearchResult(BaseModel):
     snippet: str = Field(..., description="Result snippet or summary")
     source: str = Field(..., description="Source provider")
     score: float = Field(..., description="Relevance score")
+    raw_content: Optional[str] = Field(
+        None, description="Raw content of the result when requested"
+    )
     metadata: Dict[str, Any] = Field(
         default_factory=dict, description="Additional metadata"
     )

--- a/mcp_search_hub/server.py
+++ b/mcp_search_hub/server.py
@@ -66,7 +66,7 @@ class SearchServer:
             start_time = time.time()
 
             # Check cache
-            cache_key = f"{query.query}:{query.advanced}:{query.max_results}"
+            cache_key = f"{query.query}:{query.advanced}:{query.max_results}:{query.raw_content}"
             cached_result = self.cache.get(cache_key)
             if (
                 cached_result and not query.providers
@@ -130,7 +130,9 @@ class SearchServer:
 
                 # Merge and rank results
                 combined_results = self.merger.merge_results(
-                    provider_results, max_results=query.max_results
+                    provider_results,
+                    max_results=query.max_results,
+                    raw_content=query.raw_content,
                 )
 
                 # Calculate costs

--- a/tests/test_raw_content.py
+++ b/tests/test_raw_content.py
@@ -1,0 +1,179 @@
+"""Tests for raw content functionality."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from mcp_search_hub.models.query import SearchQuery
+from mcp_search_hub.models.results import SearchResult, SearchResponse
+from mcp_search_hub.providers.linkup import LinkupProvider
+from mcp_search_hub.providers.firecrawl import FirecrawlProvider
+from mcp_search_hub.result_processing.merger import ResultMerger
+
+
+@pytest.fixture
+def mock_linkup_response():
+    """Mock response for Linkup provider."""
+    result = SearchResult(
+        title="Test Result",
+        url="https://example.com",
+        snippet="Test snippet",
+        source="linkup",
+        score=1.0,
+        raw_content="This is the raw content from Linkup",
+        metadata={"domain": "example.com"},
+    )
+    return SearchResponse(
+        results=[result],
+        query="test query",
+        total_results=1,
+        provider="linkup",
+        timing_ms=100,
+    )
+
+
+@pytest.fixture
+def mock_firecrawl_response():
+    """Mock response for Firecrawl provider."""
+    result = SearchResult(
+        title="Test Result",
+        url="https://example.com",
+        snippet="Test snippet from Firecrawl",
+        source="firecrawl",
+        score=0.8,
+        raw_content="This is the raw content from Firecrawl",
+        metadata={"source_type": "search_result"},
+    )
+    return SearchResponse(
+        results=[result],
+        query="test query",
+        total_results=1,
+        provider="firecrawl",
+        timing_ms=200,
+    )
+
+
+@pytest.mark.asyncio
+async def test_linkup_provider_with_raw_content():
+    """Test that LinkupProvider includes raw content when requested."""
+    with patch("httpx.AsyncClient") as mock_client:
+        # Setup mock response
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.elapsed.total_seconds.return_value = 0.1
+        mock_response.json.return_value = {
+            "results": [
+                {
+                    "title": "Test Title",
+                    "url": "https://example.com",
+                    "snippet": "Test snippet",
+                    "score": 0.95,
+                    "domain": "example.com",
+                    "content": "Raw content from the page",
+                }
+            ]
+        }
+
+        # Setup client mock
+        mock_client_instance = AsyncMock()
+        mock_client_instance.post.return_value = mock_response
+        mock_client.return_value = mock_client_instance
+
+        # Create provider
+        provider = LinkupProvider()
+        provider.client = mock_client_instance
+
+        # Test with raw_content=True
+        query = SearchQuery(
+            query="test query",
+            raw_content=True,
+        )
+
+        result = await provider.search(query)
+
+        # Verify results
+        assert len(result.results) == 1
+        assert result.results[0].raw_content == "Raw content from the page"
+
+        # Verify API was called with correct parameters
+        mock_client_instance.post.assert_called_once()
+        call_args = mock_client_instance.post.call_args[1]
+        assert call_args["json"]["output_type"] == "detailed"
+
+
+@pytest.mark.asyncio
+async def test_firecrawl_provider_with_raw_content():
+    """Test that FirecrawlProvider includes raw content when requested."""
+    with patch("httpx.AsyncClient") as mock_client:
+        # Setup mock response
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.json.return_value = {
+            "results": [
+                {
+                    "title": "Test Title",
+                    "url": "https://example.com",
+                    "description": "Test description",
+                    "markdown": "# Test Markdown\nContent from the page",
+                    "html": "<html><body><h1>Test HTML</h1><p>Content from the page</p></body></html>",
+                }
+            ]
+        }
+
+        # Setup client mock
+        mock_client_instance = AsyncMock()
+        mock_client_instance.post.return_value = mock_response
+        mock_client.return_value = mock_client_instance
+
+        # Create provider
+        provider = FirecrawlProvider()
+        provider.client = mock_client_instance
+
+        # Test with raw_content=True
+        query = SearchQuery(
+            query="test query",
+            raw_content=True,
+        )
+
+        result = await provider.search(query)
+
+        # Verify results
+        assert len(result.results) == 1
+        assert result.results[0].raw_content is not None
+        assert "<html>" in result.results[0].raw_content
+
+        # Verify API was called with correct parameters
+        mock_client_instance.post.assert_called_once()
+        call_args = mock_client_instance.post.call_args[1]
+        assert "scrapeOptions" in call_args["json"]
+        assert "html" in call_args["json"]["scrapeOptions"]["formats"]
+
+
+def test_merger_with_raw_content(mock_linkup_response, mock_firecrawl_response):
+    """Test that ResultMerger preserves raw content during merging."""
+    # Create a scenario with duplicate URLs but different content
+    linkup_result = mock_linkup_response.results[0]
+    firecrawl_result = mock_firecrawl_response.results[0]
+
+    # Both results have the same URL but different content
+    assert linkup_result.url == firecrawl_result.url
+    assert linkup_result.raw_content != firecrawl_result.raw_content
+
+    # Create merger
+    merger = ResultMerger()
+
+    # Test merging with raw_content=True
+    merged_results = merger.merge_results(
+        {
+            "linkup": mock_linkup_response,
+            "firecrawl": mock_firecrawl_response,
+        },
+        max_results=10,
+        raw_content=True,
+    )
+
+    # Verify results
+    assert len(merged_results) == 1  # Should be deduplicated to 1 result
+    assert merged_results[0].raw_content is not None
+
+    # Verify metadata from both sources was preserved
+    assert "domain" in merged_results[0].metadata
+    assert "source_type" in merged_results[0].metadata


### PR DESCRIPTION
## Summary
- Add support for returning raw content from search providers when requested by the client
- Implement content fetching and merging capabilities across all providers

## Implementation Details
- Added `raw_content: bool` parameter to SearchQuery model (defaults to False)
- Updated search providers to include full content when requested
- Implemented content fetching using Firecrawl scraping API
- Enhanced result processing to preserve raw content during merging
- Added comprehensive unit tests for raw content functionality

## Testing
- Added unit tests for LinkupProvider and FirecrawlProvider raw content handling
- Added tests for ResultMerger to verify content preservation during deduplication
- All tests passing and code formatted with ruff

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Implement optional raw content support across search providers and result processing

New Features:
- Add raw_content flag to SearchQuery to optionally retrieve full content
- Extend LinkupProvider and FirecrawlProvider to fetch and attach raw HTML/Markdown when raw_content=True
- Enhance ResultMerger to merge and prefer raw_content in deduplicated results
- Update server logic to include raw_content in cache keys and pass it to the merger

Enhancements:
- Update TODO.md to mark raw_content tasks as completed

Tests:
- Add unit tests for raw content handling in LinkupProvider, FirecrawlProvider, and ResultMerger