### PR TITLE
Add health check and metrics endpoints

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -17,10 +17,10 @@ _Last updated: May 15, 2025_
   - [x] Modify provider implementations to include full content when raw_content=True
   - [x] Update result processing to handle raw content appropriately
 
-- [ ] Add health check and metrics endpoints
-  - [ ] Implement health check route using @mcp.custom_route("/health")
-  - [ ] Create metrics endpoint for tracking usage statistics
-  - [ ] Add provider status checks to health endpoint
+- [x] Add health check and metrics endpoints
+  - [x] Implement health check route using @mcp.custom_route("/health")
+  - [x] Create metrics endpoint for tracking usage statistics
+  - [x] Add provider status checks to health endpoint
 
 ## Package and Version Updates
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,4 +16,11 @@ services:
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
       - CACHE_TTL=${CACHE_TTL:-3600}
       - DEFAULT_BUDGET=${DEFAULT_BUDGET}
+      - TRANSPORT=${TRANSPORT:-streamable-http}
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
     restart: unless-stopped

--- a/mcp_search_hub/models/base.py
+++ b/mcp_search_hub/models/base.py
@@ -1,1 +1,48 @@
 """Base model definitions."""
+
+from enum import Enum
+from pydantic import BaseModel
+from typing import Dict, List, Optional
+
+
+class HealthStatus(str, Enum):
+    """Health status of the server or a component."""
+    
+    OK = "ok"
+    DEGRADED = "degraded"
+    FAILED = "failed"
+
+
+class ProviderStatus(BaseModel):
+    """Status of a provider."""
+    
+    name: str
+    status: HealthStatus
+    message: Optional[str] = None
+
+
+class HealthResponse(BaseModel):
+    """Health check response."""
+    
+    status: HealthStatus
+    version: str = "1.0.0"
+    providers: Dict[str, ProviderStatus]
+    
+
+class MetricsData(BaseModel):
+    """Metrics data."""
+    
+    total_requests: int = 0
+    total_queries: int = 0
+    average_response_time_ms: float = 0
+    cache_hits: int = 0
+    cache_misses: int = 0
+    provider_usage: Dict[str, int] = {}
+    errors: int = 0
+    
+
+class MetricsResponse(BaseModel):
+    """Metrics response."""
+    
+    metrics: MetricsData
+    since: str  # ISO datetime when metrics collection started

--- a/mcp_search_hub/providers/base.py
+++ b/mcp_search_hub/providers/base.py
@@ -1,9 +1,10 @@
 """Base class for all search providers."""
 
 from abc import ABC, abstractmethod
-from typing import Any, Dict
+from typing import Any, Dict, Tuple
 from ..models.query import SearchQuery
 from ..models.results import SearchResponse
+from ..models.base import HealthStatus
 
 
 class SearchProvider(ABC):
@@ -25,3 +26,27 @@ class SearchProvider(ABC):
     def estimate_cost(self, query: SearchQuery) -> float:
         """Estimate the cost of executing the query."""
         pass
+        
+    async def check_status(self) -> Tuple[HealthStatus, str]:
+        """
+        Check the status of the provider.
+        
+        Returns:
+            A tuple of (status, message) where status is one of 
+            HealthStatus.OK, HealthStatus.DEGRADED, or HealthStatus.FAILED
+        """
+        try:
+            # Default implementation: try to make a minimal API call
+            # to check if the service is responsive
+            # Providers can override this with more specific checks
+            
+            # Make a minimal query to check if the provider is responsive
+            test_query = SearchQuery(query="test", max_results=1)
+            response = await self.search(test_query)
+            
+            if response.error:
+                return HealthStatus.DEGRADED, f"Provider returning errors: {response.error}"
+            return HealthStatus.OK, "Provider is operational"
+            
+        except Exception as e:
+            return HealthStatus.FAILED, f"Provider check failed: {str(e)}"

--- a/mcp_search_hub/utils/metrics.py
+++ b/mcp_search_hub/utils/metrics.py
@@ -1,0 +1,75 @@
+"""Metrics tracking utilities."""
+
+import time
+from datetime import datetime
+from typing import Dict, Set
+
+from ..models.base import MetricsData
+
+
+class MetricsTracker:
+    """Tracker for server metrics."""
+
+    def __init__(self):
+        """Initialize the metrics tracker."""
+        self.start_time = datetime.utcnow()
+        self.total_requests = 0
+        self.total_queries = 0
+        self.total_response_time_ms = 0.0
+        self.cache_hits = 0
+        self.cache_misses = 0
+        self.provider_usage: Dict[str, int] = {}
+        self.errors = 0
+        self.request_durations: Dict[str, float] = {}
+
+    def start_request(self, request_id: str) -> None:
+        """Start timing a request."""
+        self.request_durations[request_id] = time.time()
+        self.total_requests += 1
+
+    def end_request(self, request_id: str) -> None:
+        """End timing a request and record metrics."""
+        if request_id in self.request_durations:
+            start_time = self.request_durations.pop(request_id)
+            duration_ms = (time.time() - start_time) * 1000
+            self.total_response_time_ms += duration_ms
+
+    def record_query(self, providers_used: Set[str], from_cache: bool = False) -> None:
+        """Record a query execution."""
+        self.total_queries += 1
+
+        if from_cache:
+            self.cache_hits += 1
+        else:
+            self.cache_misses += 1
+
+        # Record provider usage
+        for provider in providers_used:
+            if provider in self.provider_usage:
+                self.provider_usage[provider] += 1
+            else:
+                self.provider_usage[provider] = 1
+
+    def record_error(self) -> None:
+        """Record an error."""
+        self.errors += 1
+
+    def get_metrics(self) -> MetricsData:
+        """Get current metrics data."""
+        avg_response_time = 0.0
+        if self.total_requests > 0:
+            avg_response_time = self.total_response_time_ms / self.total_requests
+
+        return MetricsData(
+            total_requests=self.total_requests,
+            total_queries=self.total_queries,
+            average_response_time_ms=avg_response_time,
+            cache_hits=self.cache_hits,
+            cache_misses=self.cache_misses,
+            provider_usage=self.provider_usage,
+            errors=self.errors,
+        )
+
+    def get_start_time_iso(self) -> str:
+        """Get the start time as ISO 8601 string."""
+        return self.start_time.isoformat() + "Z"

--- a/tests/test_health_metrics.py
+++ b/tests/test_health_metrics.py
@@ -1,0 +1,183 @@
+"""Tests for the health check and metrics endpoints."""
+
+import json
+import pytest
+from unittest.mock import patch, MagicMock, AsyncMock
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+from mcp_search_hub.models.base import HealthStatus
+from mcp_search_hub.server import SearchServer
+
+
+@pytest.fixture
+def mock_providers():
+    """Mock providers for testing."""
+    linkup = MagicMock()
+    linkup.check_status = AsyncMock(
+        return_value=(HealthStatus.OK, "Provider is operational")
+    )
+    linkup.name = "linkup"
+
+    exa = MagicMock()
+    exa.check_status = AsyncMock(
+        return_value=(HealthStatus.OK, "Provider is operational")
+    )
+    exa.name = "exa"
+
+    perplexity = MagicMock()
+    perplexity.check_status = AsyncMock(
+        return_value=(HealthStatus.OK, "Provider is operational")
+    )
+    perplexity.name = "perplexity"
+
+    tavily = MagicMock()
+    tavily.check_status = AsyncMock(
+        return_value=(HealthStatus.OK, "Provider is operational")
+    )
+    tavily.name = "tavily"
+
+    firecrawl = MagicMock()
+    firecrawl.check_status = AsyncMock(
+        return_value=(HealthStatus.OK, "Provider is operational")
+    )
+    firecrawl.name = "firecrawl"
+
+    return {
+        "linkup": linkup,
+        "exa": exa,
+        "perplexity": perplexity,
+        "tavily": tavily,
+        "firecrawl": firecrawl,
+    }
+
+
+@pytest.fixture
+def server(mock_providers):
+    """Create a server with mock providers for testing."""
+    with patch("mcp_search_hub.server.get_settings") as mock_settings:
+        # Configure mock settings
+        settings = MagicMock()
+        settings.providers.linkup.enabled = True
+        settings.providers.exa.enabled = True
+        settings.providers.perplexity.enabled = True
+        settings.providers.tavily.enabled = True
+        settings.providers.firecrawl.enabled = True
+        mock_settings.return_value = settings
+
+        # Create server with patch for providers
+        with patch.object(SearchServer, "__init__", return_value=None):
+            server = SearchServer()
+            server.providers = mock_providers
+            server.mcp = MagicMock()
+            server.metrics = MagicMock()
+            server.metrics.get_metrics.return_value = MagicMock()
+            server.metrics.get_start_time_iso.return_value = "2025-01-01T00:00:00Z"
+
+            # Initialize custom routes registration
+            server._register_custom_routes()
+
+            yield server
+
+
+@pytest.mark.asyncio
+async def test_health_check_all_ok(server):
+    """Test health check with all providers operational."""
+    # Get the health check function registered with @mcp.custom_route
+    health_check_func = server.mcp.custom_route.call_args_list[0][0][1]
+
+    # Mock request
+    request = MagicMock(spec=Request)
+
+    # Call health check function
+    response = await health_check_func(request)
+
+    # Verify response
+    assert isinstance(response, JSONResponse)
+    data = json.loads(response.body.decode())
+
+    assert data["status"] == HealthStatus.OK
+    assert "version" in data
+    assert len(data["providers"]) == 5  # All providers are included
+
+    # Check that all providers were checked
+    for provider in server.providers.values():
+        provider.check_status.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_health_check_degraded(server):
+    """Test health check with one provider failing."""
+    # Make one provider fail
+    server.providers["linkup"].check_status.return_value = (
+        HealthStatus.FAILED,
+        "Provider failing",
+    )
+
+    # Get the health check function registered with @mcp.custom_route
+    health_check_func = server.mcp.custom_route.call_args_list[0][0][1]
+
+    # Mock request
+    request = MagicMock(spec=Request)
+
+    # Call health check function
+    response = await health_check_func(request)
+
+    # Verify response
+    assert isinstance(response, JSONResponse)
+    data = json.loads(response.body.decode())
+
+    assert data["status"] == HealthStatus.DEGRADED  # Overall status should be degraded
+    assert data["providers"]["linkup"]["status"] == HealthStatus.FAILED
+    assert data["providers"]["linkup"]["message"] == "Provider failing"
+
+    # Other providers should still be OK
+    assert data["providers"]["exa"]["status"] == HealthStatus.OK
+
+
+@pytest.mark.asyncio
+async def test_health_check_provider_error(server):
+    """Test health check when a provider check throws an exception."""
+    # Make one provider throw an exception
+    server.providers["exa"].check_status.side_effect = Exception("Connection error")
+
+    # Get the health check function registered with @mcp.custom_route
+    health_check_func = server.mcp.custom_route.call_args_list[0][0][1]
+
+    # Mock request
+    request = MagicMock(spec=Request)
+
+    # Call health check function
+    response = await health_check_func(request)
+
+    # Verify response
+    assert isinstance(response, JSONResponse)
+    data = json.loads(response.body.decode())
+
+    assert data["status"] == HealthStatus.DEGRADED  # Overall status should be degraded
+    assert data["providers"]["exa"]["status"] == HealthStatus.FAILED
+    assert "Check failed: Connection error" in data["providers"]["exa"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_metrics_endpoint(server):
+    """Test the metrics endpoint."""
+    # Get the metrics function registered with @mcp.custom_route
+    metrics_func = server.mcp.custom_route.call_args_list[1][0][1]
+
+    # Mock request
+    request = MagicMock(spec=Request)
+
+    # Call metrics function
+    response = await metrics_func(request)
+
+    # Verify response
+    assert isinstance(response, JSONResponse)
+    data = json.loads(response.body.decode())
+
+    assert "metrics" in data
+    assert "since" in data
+    assert data["since"] == "2025-01-01T00:00:00Z"
+
+    # Verify that get_metrics was called
+    server.metrics.get_metrics.assert_called_once()


### PR DESCRIPTION
## Summary
- Added health check endpoint at `/health` that reports status of all search providers
- Created metrics endpoint at `/metrics` for tracking search usage statistics 
- Added Docker health check configuration for better container monitoring
- Implemented metrics tracking system for requests, caching, errors, and provider usage

## Test plan
- Added comprehensive unit tests for both endpoints
- Verified metrics collection during search operations
- All tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Add health check and metrics endpoints with integrated metrics tracking and Docker health check configuration

New Features:
- Expose a /health endpoint reporting overall and per-provider health statuses
- Expose a /metrics endpoint providing request, query, cache, provider usage, and error metrics

Enhancements:
- Integrate MetricsTracker into the search workflow to record request durations, cache hits, provider usage, and errors
- Add a default check_status method to SearchProvider for health assessments and aggregate provider statuses

Build:
- Add Docker Compose healthcheck on /health endpoint for container monitoring

Documentation:
- Update TODO.md checklist to mark health check and metrics tasks as completed

Tests:
- Add comprehensive unit tests for health and metrics endpoints covering operational, degraded, and error scenarios