### PR TITLE
feat: implement Perplexity MCP server integration

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -59,12 +59,12 @@ We've decided to embed official MCP servers for all providers within MCP Search 
 
 #### Official MCP Servers Implementation Plan
 
-- [ ] Perplexity: Integrate [perplexity-mcp](https://github.com/ppl-ai/modelcontextprotocol) server
-  - [ ] Create MCP Python SDK wrapper similar to Firecrawl implementation
-  - [ ] Expose all Perplexity tools through unified server (ask, research, search)
-  - [ ] Add subprocess management for Node.js MCP server
-  - [ ] Implement automatic installation check
-  - [ ] Add comprehensive tests
+- [x] Perplexity: Integrate [perplexity-mcp](https://github.com/ppl-ai/modelcontextprotocol) server
+  - [x] Create MCP Python SDK wrapper similar to Firecrawl implementation
+  - [x] Expose all Perplexity tools through unified server (ask, research, search)
+  - [x] Add subprocess management for Node.js MCP server
+  - [x] Implement automatic installation check
+  - [x] Add comprehensive tests (23 tests passing)
 
 - [x] Exa: Integrate [exa-mcp-server](https://github.com/exa-labs/exa-mcp-server)
   - [x] Create MCP Python SDK wrapper following Firecrawl pattern
@@ -113,12 +113,12 @@ For each provider integration, follow these steps:
 
 #### Perplexity Provider
 
-- [ ] Embed official [perplexity-mcp](https://github.com/ppl-ai/modelcontextprotocol) server
-- [ ] Create MCP wrapper following Firecrawl pattern
-- [ ] Expose perplexity_ask, perplexity_research, and search tools
-- [ ] Implement Node.js subprocess management
-- [ ] Add installation automation
-- [ ] Create comprehensive test suite
+- [x] Embed official [perplexity-mcp](https://github.com/ppl-ai/modelcontextprotocol) server
+- [x] Create MCP wrapper following Firecrawl pattern
+- [x] Expose perplexity_ask, perplexity_research, and search tools
+- [x] Implement Node.js subprocess management
+- [x] Add installation automation
+- [x] Create comprehensive test suite (23 tests passing)
 
 #### Exa Provider (Completed)
 
@@ -278,8 +278,8 @@ Based on our Exa integration experience, here are the immediate next steps:
   - [ ] Document any issues or limitations found
 
 - [ ] Continue MCP server integrations
-  - [ ] Perplexity MCP server integration (next priority)
-  - [ ] Linkup Python MCP server integration
+  - [x] Perplexity MCP server integration (completed)
+  - [ ] Linkup Python MCP server integration (next priority)
   - [ ] Tavily MCP server integration
 
 - [ ] Update documentation

--- a/mcp_search_hub/providers/perplexity_mcp.py
+++ b/mcp_search_hub/providers/perplexity_mcp.py
@@ -1,0 +1,291 @@
+"""
+Perplexity MCP wrapper provider that embeds the official perplexity-mcp server.
+"""
+
+import os
+import subprocess
+from typing import Any, Dict, List, Optional, Tuple
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+import logging
+
+from ..utils.errors import ProviderError
+from ..models.query import SearchQuery
+from ..models.results import SearchResult, SearchResponse
+from ..models.base import HealthStatus
+from .base import SearchProvider
+
+logger = logging.getLogger(__name__)
+
+
+class PerplexityMCPProvider:
+    """Wrapper for the Perplexity MCP server using MCP Python SDK."""
+
+    def __init__(self, api_key: Optional[str] = None):
+        """Initialize the Perplexity MCP provider with configuration."""
+        self.api_key = api_key or os.getenv("PERPLEXITY_API_KEY")
+        if not self.api_key:
+            raise ValueError("Perplexity API key is required")
+
+        self.session: Optional[ClientSession] = None
+        self.server_params = StdioServerParameters(
+            command="npx",
+            args=["perplexity-mcp"],
+            env={"PERPLEXITY_API_KEY": self.api_key, **os.environ},
+        )
+
+    async def _check_installation(self) -> bool:
+        """Check if Perplexity MCP server is installed."""
+        try:
+            result = subprocess.run(
+                ["npx", "perplexity-mcp", "--version"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            return result.returncode == 0
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            return False
+
+    async def _install_server(self):
+        """Install the Perplexity MCP server."""
+        logger.info("Installing Perplexity MCP server...")
+        try:
+            install_result = subprocess.run(
+                ["npm", "install", "-g", "perplexity-mcp"],
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+            if install_result.returncode != 0:
+                raise ProviderError(
+                    f"Failed to install Perplexity MCP server: {install_result.stderr}"
+                )
+            logger.info("Perplexity MCP server installed successfully")
+        except subprocess.TimeoutExpired:
+            raise ProviderError("Installation timed out after 60 seconds")
+        except Exception as e:
+            raise ProviderError(f"Failed to install Perplexity MCP server: {e}")
+
+    async def initialize(self):
+        """Initialize the connection to Perplexity MCP server."""
+        try:
+            # Check if the Perplexity MCP server is installed
+            if not await self._check_installation():
+                await self._install_server()
+
+            # Connect to the server
+            read_stream, write_stream = await stdio_client(self.server_params)
+            self.session = await ClientSession(read_stream, write_stream).__aenter__()
+            logger.info("Connected to Perplexity MCP server")
+
+            # Verify server is ready
+            server_info = await self.session.get_server_info()
+            logger.info(f"Perplexity MCP server info: {server_info}")
+
+        except Exception as e:
+            logger.error(f"Failed to initialize Perplexity MCP provider: {e}")
+            raise ProviderError(f"Failed to initialize Perplexity MCP provider: {e}")
+
+    async def close(self):
+        """Close the connection to Perplexity MCP server."""
+        if self.session:
+            await self.session.__aexit__(None, None, None)
+            self.session = None
+
+    async def call_tool(self, tool_name: str, arguments: Dict[str, Any]) -> Any:
+        """Call a tool on the Perplexity MCP server."""
+        if not self.session:
+            await self.initialize()
+
+        try:
+            result = await self.session.call_tool(tool_name, arguments=arguments)
+            return result
+        except Exception as e:
+            logger.error(f"Error calling tool {tool_name}: {e}")
+            raise ProviderError(f"Failed to call Perplexity tool {tool_name}: {e}")
+
+    async def list_tools(self) -> List[Dict[str, Any]]:
+        """List available tools from the Perplexity MCP server."""
+        if not self.session:
+            await self.initialize()
+
+        try:
+            tools = await self.session.list_tools()
+            return [tool.model_dump() for tool in tools]
+        except Exception as e:
+            logger.error(f"Error listing tools: {e}")
+            raise ProviderError(f"Failed to list Perplexity tools: {e}")
+
+
+class PerplexityProvider(SearchProvider):
+    """Search provider that uses the Perplexity MCP server for AI-powered search."""
+
+    name = "perplexity"
+
+    def __init__(self, config: Dict[str, Any]):
+        """Initialize the Perplexity search provider."""
+        super().__init__()
+        self.api_key = config.get("perplexity_api_key", "")
+        self.mcp_wrapper = PerplexityMCPProvider(api_key=self.api_key)
+        self._initialized = False
+
+    async def _ensure_initialized(self):
+        """Ensure the MCP client is initialized."""
+        if not self._initialized:
+            await self.mcp_wrapper.initialize()
+            self._initialized = True
+
+    async def search(self, query: SearchQuery) -> SearchResponse:
+        """
+        Execute a search using the perplexity_ask tool.
+
+        This method provides basic search functionality through the Perplexity MCP server.
+        """
+        await self._ensure_initialized()
+
+        try:
+            # Use perplexity_ask for general search functionality
+            result = await self.mcp_wrapper.call_tool(
+                "perplexity_ask",
+                {
+                    "messages": [
+                        {
+                            "role": "system",
+                            "content": "You are a search assistant. Provide web search results only, not summaries or answers. Include source URLs when available.",
+                        },
+                        {"role": "user", "content": query.query},
+                    ]
+                },
+            )
+
+            # Parse the result and format it as search results
+            results = []
+            
+            # Extract sources from the response if available
+            if isinstance(result, dict):
+                sources = result.get("sources", [])
+                citations = result.get("citations", [])
+                content = result.get("content", "")
+                
+                # Process sources
+                for idx, source in enumerate(sources):
+                    search_result = SearchResult(
+                        title=source.get("title", ""),
+                        url=source.get("url", ""),
+                        snippet=source.get("snippet", ""),
+                        raw_content=content if query.raw_content else None,
+                        source="perplexity",
+                        score=1.0 - (idx * 0.1),  # Decreasing score by position
+                        metadata={
+                            "source_id": source.get("id", ""),
+                            "domain": source.get("domain", ""),
+                            "published_date": source.get("published_date", ""),
+                        },
+                    )
+                    results.append(search_result)
+                
+                # If no sources but we have content, create a single result
+                if not sources and content:
+                    search_result = SearchResult(
+                        title=f"Perplexity Answer: {query.query[:50]}...",
+                        url="https://perplexity.ai",
+                        snippet=content[:200] + "..." if len(content) > 200 else content,
+                        raw_content=content if query.raw_content else None,
+                        source="perplexity",
+                        score=1.0,
+                        metadata={"citations": citations},
+                    )
+                    results.append(search_result)
+
+            return SearchResponse(
+                results=results[:query.max_results],
+                query=query.query,
+                total_results=len(results),
+                provider="perplexity",
+                timing_ms=0,  # MCP doesn't provide timing info
+            )
+
+        except Exception as e:
+            logger.error(f"Perplexity search error: {e}")
+            # Return error response
+            return SearchResponse(
+                results=[],
+                query=query.query,
+                total_results=0,
+                provider="perplexity",
+                error=str(e),
+            )
+
+    async def perplexity_research(self, query: str, **kwargs) -> Dict[str, Any]:
+        """Perform deep research using Perplexity."""
+        await self._ensure_initialized()
+        return await self.mcp_wrapper.call_tool(
+            "perplexity_research",
+            {
+                "messages": [
+                    {"role": "user", "content": query}
+                ],
+                **kwargs
+            }
+        )
+
+    async def perplexity_reason(self, query: str, **kwargs) -> Dict[str, Any]:
+        """Perform reasoning tasks using Perplexity."""
+        await self._ensure_initialized()
+        return await self.mcp_wrapper.call_tool(
+            "perplexity_reason",
+            {
+                "messages": [
+                    {"role": "user", "content": query}
+                ],
+                **kwargs
+            }
+        )
+
+    def get_capabilities(self) -> Dict[str, Any]:
+        """Return Perplexity capabilities."""
+        return {
+            "content_types": ["news", "current_events", "general", "technical"],
+            "features": {
+                "llm_processing": True,
+                "source_attribution": True,
+                "real_time": True,
+                "reasoning": True,
+                "research": True,
+            },
+            "quality_metrics": {"simple_qa_score": 0.86},
+        }
+
+    def estimate_cost(self, query: SearchQuery) -> float:
+        """Estimate the cost of executing the query."""
+        # Perplexity costs ~$0.015 per query for basic, ~$0.03 for advanced
+        return 0.03 if query.advanced else 0.015
+
+    async def check_status(self) -> Tuple[HealthStatus, str]:
+        """Check the status of the Perplexity provider."""
+        try:
+            await self._ensure_initialized()
+            # Try to list tools to verify connection
+            tools = await self.mcp_wrapper.list_tools()
+            if tools:
+                return HealthStatus.OK, "Perplexity provider is operational"
+            else:
+                return HealthStatus.FAILED, "No tools available from Perplexity MCP server"
+        except Exception as e:
+            logger.error(f"Perplexity health check failed: {e}")
+            return HealthStatus.FAILED, f"Health check failed: {str(e)}"
+
+    async def cleanup(self):
+        """Clean up resources."""
+        await self.mcp_wrapper.close()
+        self._initialized = False
+
+    async def __aenter__(self):
+        await self._ensure_initialized()
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        await self.cleanup()

--- a/tests/test_exa_mcp.py
+++ b/tests/test_exa_mcp.py
@@ -28,7 +28,9 @@ class TestExaMCPProvider:
         """Test successful initialization."""
         with (
             patch("subprocess.run") as mock_run,
-            patch("mcp_search_hub.providers.exa_mcp.stdio_client", new_callable=AsyncMock) as mock_client,
+            patch(
+                "mcp_search_hub.providers.exa_mcp.stdio_client", new_callable=AsyncMock
+            ) as mock_client,
             patch(
                 "mcp_search_hub.providers.exa_mcp.ClientSession"
             ) as mock_session_class,
@@ -60,7 +62,9 @@ class TestExaMCPProvider:
         """Test initialization with server installation."""
         with (
             patch("subprocess.run") as mock_run,
-            patch("mcp_search_hub.providers.exa_mcp.stdio_client", new_callable=AsyncMock) as mock_client,
+            patch(
+                "mcp_search_hub.providers.exa_mcp.stdio_client", new_callable=AsyncMock
+            ) as mock_client,
             patch(
                 "mcp_search_hub.providers.exa_mcp.ClientSession"
             ) as mock_session_class,
@@ -119,14 +123,18 @@ class TestExaMCPProvider:
         # Mock session to be set after initialization
         mock_session = AsyncMock()
         mock_session.call_tool = AsyncMock(return_value={"result": "test"})
-        
+
         async def mock_initialize():
             exa_mcp_provider.session = mock_session
-            
-        with patch.object(exa_mcp_provider, "initialize", side_effect=mock_initialize) as mock_init:
+
+        with patch.object(
+            exa_mcp_provider, "initialize", side_effect=mock_initialize
+        ) as mock_init:
             exa_mcp_provider.session = None
-            result = await exa_mcp_provider.call_tool("web_search_exa", {"query": "test"})
-            
+            result = await exa_mcp_provider.call_tool(
+                "web_search_exa", {"query": "test"}
+            )
+
             mock_init.assert_called_once()
             assert result == {"result": "test"}
 

--- a/tests/test_perplexity_mcp.py
+++ b/tests/test_perplexity_mcp.py
@@ -1,0 +1,334 @@
+"""
+Test suite for Perplexity MCP provider integration.
+"""
+import asyncio
+from unittest.mock import MagicMock, patch, AsyncMock
+
+import pytest
+import pytest_asyncio
+
+from mcp_search_hub.models.query import SearchQuery
+from mcp_search_hub.providers.perplexity_mcp import PerplexityMCPProvider, PerplexityProvider
+from mcp_search_hub.utils.errors import ProviderError
+
+
+class TestPerplexityMCPProvider:
+    """Tests for PerplexityMCPProvider."""
+
+    @pytest_asyncio.fixture
+    async def provider(self):
+        """Create an PerplexityMCPProvider instance."""
+        provider = PerplexityMCPProvider(api_key="test_key")
+        yield provider
+        # Cleanup
+        if provider.session:
+            await provider.close()
+
+    def test_init(self):
+        """Test provider initialization."""
+        provider = PerplexityMCPProvider(api_key="test_key")
+        assert provider.api_key == "test_key"
+        assert provider.session is None
+        assert provider.server_params.command == "npx"
+        assert "perplexity-mcp" in provider.server_params.args
+
+    @pytest.mark.asyncio
+    async def test_check_installation_success(self, provider):
+        """Test successful installation check."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            result = await provider._check_installation()
+            assert result is True
+            mock_run.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_check_installation_failure(self, provider):
+        """Test failed installation check."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1)
+            result = await provider._check_installation()
+            assert result is False
+
+    @pytest.mark.asyncio
+    async def test_install_server_success(self, provider):
+        """Test successful server installation."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            await provider._install_server()
+            mock_run.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_install_server_failure(self, provider):
+        """Test failed server installation."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stderr="Installation failed")
+            with pytest.raises(ProviderError):
+                await provider._install_server()
+
+    @pytest.mark.asyncio
+    async def test_initialize_success(self, provider):
+        """Test successful initialization."""
+        with patch.object(provider, "_check_installation", return_value=True):
+            with patch("mcp_search_hub.providers.perplexity_mcp.stdio_client") as mock_stdio:
+                # Mock the stdio streams and session
+                mock_read_stream = MagicMock()
+                mock_write_stream = MagicMock()
+                
+                async def mock_stdio_client(*args, **kwargs):
+                    return (mock_read_stream, mock_write_stream)
+                
+                mock_stdio.side_effect = mock_stdio_client
+                
+                mock_session = AsyncMock()
+                mock_session.get_server_info.return_value = {"name": "perplexity-mcp"}
+                
+                with patch("mcp_search_hub.providers.perplexity_mcp.ClientSession") as mock_client_session:
+                    mock_client_session.return_value.__aenter__.return_value = mock_session
+                    
+                    await provider.initialize()
+                    assert provider.session == mock_session
+
+    @pytest.mark.asyncio
+    async def test_initialize_with_installation(self, provider):
+        """Test initialization with installation needed."""
+        with patch.object(provider, "_check_installation", return_value=False):
+            with patch.object(provider, "_install_server") as mock_install:
+                with patch("mcp_search_hub.providers.perplexity_mcp.stdio_client") as mock_stdio:
+                    # Mock the stdio streams and session
+                    mock_read_stream = MagicMock()
+                    mock_write_stream = MagicMock()
+                    
+                    async def mock_stdio_client(*args, **kwargs):
+                        return (mock_read_stream, mock_write_stream)
+                    
+                    mock_stdio.side_effect = mock_stdio_client
+                    
+                    mock_session = AsyncMock()
+                    mock_session.get_server_info.return_value = {"name": "perplexity-mcp"}
+                    
+                    with patch("mcp_search_hub.providers.perplexity_mcp.ClientSession") as mock_client_session:
+                        mock_client_session.return_value.__aenter__.return_value = mock_session
+                        
+                        await provider.initialize()
+                        mock_install.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_call_tool_success(self, provider):
+        """Test successful tool calling."""
+        provider.session = AsyncMock()
+        provider.session.call_tool.return_value = {"result": "success"}
+        
+        result = await provider.call_tool("perplexity_ask", {"messages": [{"role": "user", "content": "test"}]})
+        assert result == {"result": "success"}
+
+    @pytest.mark.asyncio
+    async def test_call_tool_error(self, provider):
+        """Test tool calling error."""
+        provider.session = AsyncMock()
+        provider.session.call_tool.side_effect = Exception("Tool error")
+        
+        with pytest.raises(ProviderError):
+            await provider.call_tool("perplexity_ask", {"messages": [{"role": "user", "content": "test"}]})
+
+    @pytest.mark.asyncio
+    async def test_list_tools_success(self, provider):
+        """Test successful tools listing."""
+        provider.session = AsyncMock()
+        mock_tool = MagicMock()
+        mock_tool.model_dump.return_value = {"name": "perplexity_ask", "description": "Test tool"}
+        provider.session.list_tools.return_value = [mock_tool]
+        
+        tools = await provider.list_tools()
+        assert len(tools) == 1
+        assert tools[0]["name"] == "perplexity_ask"
+
+    @pytest.mark.asyncio
+    async def test_close(self, provider):
+        """Test closing connection."""
+        mock_session = MagicMock()
+        provider.session = mock_session
+        
+        await provider.close()
+        assert provider.session is None
+
+
+class TestPerplexityProvider:
+    """Tests for PerplexityProvider."""
+
+    @pytest_asyncio.fixture
+    async def provider(self):
+        """Create an PerplexityProvider instance."""
+        provider = PerplexityProvider({"perplexity_api_key": "test_key"})
+        yield provider
+        # Cleanup
+        if provider._initialized:
+            await provider.cleanup()
+
+    def test_init(self):
+        """Test provider initialization."""
+        provider = PerplexityProvider({"perplexity_api_key": "test_key"})
+        assert provider.api_key == "test_key"
+        assert provider._initialized is False
+        assert isinstance(provider.mcp_wrapper, PerplexityMCPProvider)
+
+    @pytest.mark.asyncio
+    async def test_ensure_initialized(self, provider):
+        """Test ensuring provider is initialized."""
+        with patch.object(provider.mcp_wrapper, "initialize") as mock_init:
+            await provider._ensure_initialized()
+            mock_init.assert_called_once()
+            assert provider._initialized is True
+
+    @pytest.mark.asyncio
+    async def test_search_success(self, provider):
+        """Test successful search operation."""
+        query = SearchQuery(query="test query", max_results=5)
+        
+        # Mock the MCP wrapper response
+        mock_response = {
+            "sources": [
+                {
+                    "title": "Test Result 1",
+                    "url": "https://example.com/1",
+                    "snippet": "Test snippet 1",
+                    "domain": "example.com",
+                },
+                {
+                    "title": "Test Result 2",
+                    "url": "https://example.com/2",
+                    "snippet": "Test snippet 2",
+                    "domain": "example.com",
+                },
+            ],
+            "content": "Test answer content",
+            "citations": ["1", "2"],
+        }
+        
+        with patch.object(provider, "_ensure_initialized"):
+            with patch.object(provider.mcp_wrapper, "call_tool", 
+                            return_value=mock_response) as mock_call:
+                result = await provider.search(query)
+                
+                assert len(result.results) == 2
+                assert result.results[0].title == "Test Result 1"
+                assert result.results[0].url == "https://example.com/1"
+                assert result.results[0].source == "perplexity"
+                assert result.provider == "perplexity"
+                assert result.total_results == 2
+                
+                mock_call.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_search_with_content_only(self, provider):
+        """Test search with content but no sources."""
+        query = SearchQuery(query="test query", max_results=5, raw_content=True)
+        
+        # Mock response with only content
+        mock_response = {
+            "content": "Test answer content",
+            "citations": ["1", "2"],
+        }
+        
+        with patch.object(provider, "_ensure_initialized"):
+            with patch.object(provider.mcp_wrapper, "call_tool", 
+                            return_value=mock_response):
+                result = await provider.search(query)
+                
+                assert len(result.results) == 1
+                assert "Perplexity Answer" in result.results[0].title
+                # Note: SearchResult doesn't have a content attribute, it uses snippet
+                assert result.results[0].snippet == "Test answer content"
+
+    @pytest.mark.asyncio
+    async def test_search_error(self, provider):
+        """Test search error handling."""
+        query = SearchQuery(query="test query")
+        
+        with patch.object(provider, "_ensure_initialized"):
+            with patch.object(provider.mcp_wrapper, "call_tool", 
+                            side_effect=Exception("Search failed")):
+                result = await provider.search(query)
+                
+                assert len(result.results) == 0
+                assert result.error == "Search failed"
+
+    @pytest.mark.asyncio
+    async def test_perplexity_research(self, provider):
+        """Test perplexity research method."""
+        with patch.object(provider, "_ensure_initialized"):
+            with patch.object(provider.mcp_wrapper, "call_tool", 
+                            return_value={"result": "research"}) as mock_call:
+                result = await provider.perplexity_research("test topic")
+                
+                assert result == {"result": "research"}
+                mock_call.assert_called_with(
+                    "perplexity_research",
+                    {"messages": [{"role": "user", "content": "test topic"}]}
+                )
+
+    @pytest.mark.asyncio
+    async def test_perplexity_reason(self, provider):
+        """Test perplexity reasoning method."""
+        with patch.object(provider, "_ensure_initialized"):
+            with patch.object(provider.mcp_wrapper, "call_tool", 
+                            return_value={"result": "reasoning"}) as mock_call:
+                result = await provider.perplexity_reason("test reasoning")
+                
+                assert result == {"result": "reasoning"}
+                mock_call.assert_called_with(
+                    "perplexity_reason",
+                    {"messages": [{"role": "user", "content": "test reasoning"}]}
+                )
+
+    def test_get_capabilities(self, provider):
+        """Test getting provider capabilities."""
+        capabilities = provider.get_capabilities()
+        
+        assert "content_types" in capabilities
+        assert "news" in capabilities["content_types"]
+        assert "current_events" in capabilities["content_types"]
+        assert capabilities["features"]["llm_processing"] is True
+        assert capabilities["features"]["source_attribution"] is True
+        assert capabilities["features"]["reasoning"] is True
+
+    def test_estimate_cost(self, provider):
+        """Test cost estimation."""
+        basic_query = SearchQuery(query="test", advanced=False)
+        advanced_query = SearchQuery(query="test", advanced=True)
+        
+        basic_cost = provider.estimate_cost(basic_query)
+        advanced_cost = provider.estimate_cost(advanced_query)
+        
+        assert basic_cost == 0.015
+        assert advanced_cost == 0.03
+
+    @pytest.mark.asyncio
+    async def test_check_status_success(self, provider):
+        """Test successful status check."""
+        with patch.object(provider, "_ensure_initialized"):
+            with patch.object(provider.mcp_wrapper, "list_tools", 
+                            return_value=[{"name": "perplexity_ask"}]):
+                status, message = await provider.check_status()
+                
+                assert status.value == "ok"
+                assert "operational" in message
+
+    @pytest.mark.asyncio
+    async def test_check_status_failure(self, provider):
+        """Test failed status check."""
+        with patch.object(provider, "_ensure_initialized", 
+                        side_effect=Exception("Connection failed")):
+            status, message = await provider.check_status()
+            
+            assert status.value == "failed"
+            assert "Connection failed" in message
+
+    @pytest.mark.asyncio
+    async def test_cleanup(self, provider):
+        """Test cleanup method."""
+        provider._initialized = True
+        
+        with patch.object(provider.mcp_wrapper, "close") as mock_close:
+            await provider.cleanup()
+            mock_close.assert_called_once()
+            assert provider._initialized is False


### PR DESCRIPTION
## Summary
- Integrate official perplexity-mcp server into MCP Search Hub
- Create comprehensive wrapper and testing infrastructure
- Enable AI-powered search capabilities through Perplexity

## Test Plan
- [x] Created and ran 23 comprehensive tests
- [x] All tests passing
- [x] Manual testing with API key pending

## Summary by Sourcery

Integrate the official Perplexity MCP server into MCP Search Hub by adding a dedicated provider wrapper, registering its tools, configuring API key support with installation checks, and validating the integration with a new comprehensive test suite.

New Features:
- Integrate PerplexityMCPProvider into MCP Search Hub and expose perplexity_ask, perplexity_research, and perplexity_reason tools
- Add PerplexityProvider class for AI-powered search using the Perplexity MCP server

Enhancements:
- Configure PerplexityProvider initialization with API key retrieval and automatic server installation check

Documentation:
- Update TODO.md to mark Perplexity MCP server integration tasks as completed

Tests:
- Add comprehensive 23-test suite for Perplexity MCP integration covering installation, initialization, tool invocation, search responses, status checks, and cleanup
- Apply minor formatting adjustments to existing Exa MCP tests