### PR TITLE
feat: update provider integration status

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ We've implemented an innovative approach: **embedding all official provider MCP 
 This architectural decision applies to all providers:
 
 - **Firecrawl**: Successfully embedded with all tools available
-- **Perplexity**: In progress - will expose ask, research, and search tools
-- **Exa**: In progress - will expose web_search_exa, research_paper_search, and more
-- **Linkup**: In progress - Python-to-Python MCP communication for search
-- **Tavily**: In progress - will expose tavily-search and tavily-extract tools
+- **Perplexity**: Successfully embedded with all tools available
+- **Exa**: Successfully embedded with all tools available
+- **Linkup**: Successfully embedded with all tools available
+- **Tavily**: Successfully embedded with all tools available
 
 Benefits of this approach:
 
@@ -557,13 +557,13 @@ MCP Search Hub embeds all official provider MCP servers, giving you access to th
 - `firecrawl_deep_research`: Comprehensive research automation
 - `firecrawl_generate_llmstxt`: Generate LLMs.txt files
 
-#### Perplexity (In Progress)
+#### Perplexity (Completed)
 
 - `perplexity_ask`: Conversational search with AI
 - `perplexity_research`: Deep research capabilities
 - `perplexity_search`: Web search with citations
 
-#### Exa (In Progress)
+#### Exa (Completed)
 
 - `web_search_exa`: Semantic web search
 - `research_paper_search`: Academic paper search
@@ -572,11 +572,11 @@ MCP Search Hub embeds all official provider MCP servers, giving you access to th
 - `wikipedia_search_exa`: Wikipedia search
 - `github_search`: GitHub repository search
 
-#### Linkup (In Progress)
+#### Linkup (Completed)
 
 - `linkup_search`: Premium content search with real-time results
 
-#### Tavily (In Progress)
+#### Tavily (Completed)
 
 - `tavily_search`: RAG-optimized search
 - `tavily_extract`: Content extraction

--- a/mcp_search_hub/result_processing/merger.py
+++ b/mcp_search_hub/result_processing/merger.py
@@ -10,20 +10,19 @@ from .deduplication import remove_duplicates
 
 class ResultMerger:
     """Merges and ranks results from multiple providers."""
-    
+
     # Provider quality weights for ranking
     DEFAULT_WEIGHTS = {
-        "linkup": 1.0,      # Excellent for real-time and factual accuracy
-        "exa": 0.95,        # Strong academic and research focus
+        "linkup": 1.0,  # Excellent for real-time and factual accuracy
+        "exa": 0.95,  # Strong academic and research focus
         "perplexity": 0.9,  # Good for comprehensive searches
-        "tavily": 0.85,     # Good general search with relevance scoring
-        "firecrawl": 0.8,   # Specialized for content extraction
+        "tavily": 0.85,  # Good general search with relevance scoring
+        "firecrawl": 0.8,  # Specialized for content extraction
     }
 
     def __init__(self, provider_weights: dict[str, float] | None = None):
-        """
-        Initialize the result merger.
-        
+        """Initialize the result merger.
+
         Args:
             provider_weights: Optional custom weight mapping for providers
         """
@@ -112,15 +111,16 @@ class ResultMerger:
         return merged_results
 
     def _rank_results(
-        self, results: list[SearchResult], provider_results: dict[str, SearchResponse | list[SearchResult]]
+        self,
+        results: list[SearchResult],
+        provider_results: dict[str, SearchResponse | list[SearchResult]],
     ) -> list[SearchResult]:
-        """
-        Rank results based on provider quality and result scores.
-        
+        """Rank results based on provider quality and result scores.
+
         Uses a multi-factor ranking algorithm:
-        1. Provider quality weight
-        2. Original result score
-        3. Consensus boost (results appearing in multiple providers)
+            1. Provider quality weight
+            2. Original result score
+            3. Consensus boost (results appearing in multiple providers)
         """
         # Apply consensus boost for results appearing in multiple providers
         url_counts = {}
@@ -154,11 +154,12 @@ class ResultMerger:
         )
 
     def rank_by_weighted_score(
-        self, results: list[SearchResult], custom_weights: dict[str, float] | None = None
+        self,
+        results: list[SearchResult],
+        custom_weights: dict[str, float] | None = None,
     ) -> list[SearchResult]:
-        """
-        Simple ranking by applying source weights to scores.
-        
+        """Simple ranking by applying source weights to scores.
+
         This method is provided for compatibility and simple use cases.
         The main merge_results method provides more sophisticated ranking.
 
@@ -170,7 +171,7 @@ class ResultMerger:
             Ranked list of results
         """
         weights = custom_weights or self.provider_weights
-        
+
         for result in results:
             weight = weights.get(result.source, 0.5)
             result.metadata["weighted_score"] = result.score * weight


### PR DESCRIPTION
## Summary
- mark provider integrations as completed in README
- tidy whitespace warnings in merger

## Testing
- `ruff check . --fix`
- `ruff format .`
- `uv run pytest --cov=mcp_search_hub` *(fails: No route to host)*

## Summary by Sourcery

Mark all official provider integrations as completed in the README and tidy up whitespace and documentation formatting in the ResultMerger module.

Enhancements:
- Clean up trailing spaces, adjust indentation, and standardize docstring formatting in merger.py

Documentation:
- Update Perplexity, Exa, Linkup, and Tavily statuses to Completed in README