### PR TITLE
feat(logging): Configure early logging

### DIFF
--- a/mcp_search_hub/main.py
+++ b/mcp_search_hub/main.py
@@ -8,6 +8,7 @@ import signal
 
 from .config import get_settings
 from .server import SearchServer
+from .utils.logging import configure_logging
 
 
 async def shutdown(server: SearchServer):
@@ -97,6 +98,10 @@ def main():
 
     # Get settings (now incorporating any command-line arguments)
     settings = get_settings()
+
+    # Configure logging early based on settings
+    configure_logging(settings.log_level)
+
     server = SearchServer()
 
     # Setup signal handlers for graceful shutdown

--- a/tests/test_main_logging.py
+++ b/tests/test_main_logging.py
@@ -1,0 +1,45 @@
+import logging
+from argparse import Namespace
+
+import mcp_search_hub.main as main_mod
+
+
+def test_main_configures_logging(monkeypatch, caplog):
+    caplog.set_level(logging.DEBUG)
+
+    args = Namespace(
+        transport=None,
+        host=None,
+        port=None,
+        log_level="WARNING",
+        linkup_api_key=None,
+        exa_api_key=None,
+        perplexity_api_key=None,
+        tavily_api_key=None,
+        firecrawl_api_key=None,
+    )
+
+    monkeypatch.setattr(main_mod, "parse_args", lambda: args)
+
+    logged_levels = []
+
+    def dummy_init(self):
+        pass
+
+    def dummy_run(self, transport, host, port, log_level):
+        logger = logging.getLogger("mcp_search_hub")
+        logged_levels.append(logger.getEffectiveLevel())
+        logger.debug("debug message")
+        logger.warning("warning message")
+
+    monkeypatch.setattr(main_mod.SearchServer, "__init__", dummy_init)
+    monkeypatch.setattr(main_mod.SearchServer, "run", dummy_run)
+
+    monkeypatch.delenv("LOG_LEVEL", raising=False)
+    main_mod.get_settings.cache_clear()
+    main_mod.main()
+
+    assert logged_levels == [logging.WARNING]
+    messages = [rec.message for rec in caplog.records]
+    assert "warning message" in messages
+    assert "debug message" not in messages


### PR DESCRIPTION
## Summary
- call `configure_logging` early in `main`
- add regression test for log configuration

## Testing
- `pytest -q tests/test_main_logging.py`

## Summary by Sourcery

Configure the logging system at the start of the application’s main function and add a test to ensure log levels are applied correctly.

New Features:
- Configure logging early in the main entrypoint based on settings

Tests:
- Add a regression test to verify that main respects the configured log level