### PR TITLE
Update Task Priorities - Move Code Organization to MVP

### DIFF
--- a/tasks/TODO-V2.md
+++ b/tasks/TODO-V2.md
@@ -21,17 +21,7 @@ Last updated: May 25, 2025
   - [ ] Add serverless deployment support
   - [ ] Document hosting provider options
 
-### Code Quality Improvements
-
-#### 3. Code Organization and Standards ⭐⭐
-
-- [ ] Apply consistent architectural patterns across all modules
-- [ ] Standardize error handling and exception patterns
-- [ ] Implement consistent service interfaces for all components
-- [ ] Improve documentation with type hints and docstrings
-- [ ] Create architecture decision records (ADRs) for design choices
-
-#### 4. Performance Optimization ⭐
+### Performance Optimization ⭐
 
 - [ ] Conduct performance profiling and optimize bottlenecks
 - [ ] Implement async context manager pattern consistently
@@ -44,27 +34,25 @@ Last updated: May 25, 2025
 ### Immediate Focus (v2.0 Priority)
 
 - Implement structured logging and request tracing
-- Standardize error handling patterns across the codebase
 - Create Kubernetes configuration
 
 ### Secondary Focus (v2.0)
 
 - Support additional deployment options (Kubernetes, serverless)
-- Apply consistent architectural patterns
 - Conduct performance profiling and optimize bottlenecks
 
 ### Future Considerations (v2.1+)
 
 - Streaming response option for large result sets
 - Advanced monitoring and observability integrations
-- Architecture decision records for design choices
 
 ### Resource Allocation Suggestion
 
-For the remaining tasks, we recommend:
+For the v2.0 tasks, we recommend:
 
 - 1 developer focused on Deployment & Operations
-- 1 developer focused on Code Organization and Standards
 - 1 developer (with performance expertise) for Performance Optimization tasks
 
 This parallel approach will allow for faster completion while maintaining focus in each area.
+
+> Note: Code Organization and Standards tasks have been moved to the MVP scope in the main TODO.md file.

--- a/tasks/TODO.md
+++ b/tasks/TODO.md
@@ -2,9 +2,21 @@
 
 Last updated: May 25, 2025
 
-## MVP Complete! ✅
+## MVP Status: Final Tasks in Progress
 
-All high-priority tasks for the initial MVP release have been completed. The project is now ready for production use with:
+Most high-priority tasks for the initial MVP release have been completed. We still need to address code quality improvements to finalize the MVP:
+
+### Code Organization and Standards ⭐⭐ (MVP Final Tasks)
+
+- [ ] Apply consistent architectural patterns across all modules
+- [ ] Standardize error handling and exception patterns
+- [ ] Implement consistent service interfaces for all components
+- [ ] Improve documentation with type hints and docstrings
+- [ ] Create architecture decision records (ADRs) for design choices
+
+## Completed MVP Features
+
+The project already includes the following production-ready features:
 
 - Unified provider implementation with GenericMCPProvider
 - Simplified routing system with UnifiedRouter
@@ -23,8 +35,8 @@ For post-MVP enhancements, see:
 - [TODO-V2.md](TODO-V2.md) - Future enhancements for v2.0
 - [TODO-COMPLETED.md](TODO-COMPLETED.md) - Historical record of completed tasks
 
-To contribute to future development, please:
-1. Select an item from TODO-V2.md
+To contribute to development, please:
+1. Select an item from this file or TODO-V2.md
 2. Create a feature branch using conventional commits format
 3. Implement the feature with comprehensive tests
 4. Submit a PR with a detailed description of changes


### PR DESCRIPTION
## Summary
- Move Code Organization and Standards tasks from TODO-V2.md to TODO.md
- Mark these tasks as final MVP requirements to be completed
- Update implementation planning sections accordingly

## Rationale
These code quality improvements are essential for a maintainable codebase even in the MVP phase, as they will:
- Ensure consistent patterns across the codebase
- Standardize error handling for better debugging
- Improve documentation with type hints and docstrings
- Establish architectural decision records to document design choices

These tasks represent the final set of improvements needed before considering the MVP complete.

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Consolidate code quality task lists by migrating code organization and standards items to the primary TODO as final MVP requirements, removing them from the v2 backlog, and refining task headings and contribution guidelines.

Enhancements:
- Update MVP status messaging and streamline task section headings.

Documentation:
- Move code organization and standards tasks into TODO.md as final MVP tasks and remove them from TODO-V2.md.
- Revise contribution instructions to include both current MVP and v2 backlog items.